### PR TITLE
feat: make dashboard and statistics stat panels clickable to filter c…

### DIFF
--- a/src/stores/collection.ts
+++ b/src/stores/collection.ts
@@ -17,6 +17,7 @@ import type { Game } from '@/types/game'
 
 export type SortOrder = 'PURCHASE' | 'NAME' | 'RATING' | 'PLATFORM' | 'ID'
 export type FormatFilter = 'all' | 'physical' | 'digital'
+export type StatusFilter = 'none' | 'completed' | 'favorite' | 'this-month' | 'hundred-percent'
 
 const PAGE_SIZE = 20
 
@@ -27,6 +28,8 @@ export const useCollectionStore = defineStore('collection', () => {
   const filterPlatform = ref('')
   const filterGenre = ref('')
   const filterFormat = ref<FormatFilter>('all')
+  const filterStatus = ref<StatusFilter>('none')
+  const filterYear = ref<number | 'all'>('all')
   const sortOrder = ref<SortOrder>('PURCHASE')
   const currentPage = ref(1)
 
@@ -76,6 +79,27 @@ export const useCollectionStore = defineStore('collection', () => {
       result = result.filter(g => g.digital === true)
     } else if (filterFormat.value === 'physical') {
       result = result.filter(g => !g.digital)
+    }
+    if (filterStatus.value === 'completed') {
+      result = result.filter(g => g.completed === true)
+    } else if (filterStatus.value === 'favorite') {
+      result = result.filter(g => g.favorite === true)
+    } else if (filterStatus.value === 'hundred-percent') {
+      result = result.filter(g => g.hundredpercent === true)
+    } else if (filterStatus.value === 'this-month') {
+      const now = new Date()
+      result = result.filter(g => {
+        if (!g.buydate) return false
+        const d = (g.buydate as Timestamp).toDate()
+        return d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth()
+      })
+    }
+    if (filterYear.value !== 'all') {
+      const y = filterYear.value
+      result = result.filter(g => {
+        if (!g.buydate) return false
+        return (g.buydate as Timestamp).toDate().getFullYear() === y
+      })
     }
 
     return sortGames(result, sortOrder.value)
@@ -166,6 +190,16 @@ export const useCollectionStore = defineStore('collection', () => {
     currentPage.value = 1
   }
 
+  function setStatusFilter(status: StatusFilter) {
+    filterStatus.value = status
+    currentPage.value = 1
+  }
+
+  function setYearFilter(year: number | 'all') {
+    filterYear.value = year
+    currentPage.value = 1
+  }
+
   function setSortOrder(order: SortOrder) {
     sortOrder.value = order
     currentPage.value = 1
@@ -176,6 +210,8 @@ export const useCollectionStore = defineStore('collection', () => {
     filterPlatform.value = ''
     filterGenre.value = ''
     filterFormat.value = 'all'
+    filterStatus.value = 'none'
+    filterYear.value = 'all'
     currentPage.value = 1
   }
 
@@ -186,6 +222,8 @@ export const useCollectionStore = defineStore('collection', () => {
     filterPlatform,
     filterGenre,
     filterFormat,
+    filterStatus,
+    filterYear,
     sortOrder,
     currentPage,
     totalFilteredPages,
@@ -206,6 +244,8 @@ export const useCollectionStore = defineStore('collection', () => {
     setPlatformFilter,
     setGenreFilter,
     setFormatFilter,
+    setStatusFilter,
+    setYearFilter,
     setSortOrder,
     clearFilters
   }

--- a/src/views/CollectionView.vue
+++ b/src/views/CollectionView.vue
@@ -65,6 +65,24 @@
             <span class="text-caption text-medium-emphasis">
               {{ collectionStore.filteredCollection.length }} game(s)
             </span>
+            <v-chip
+              v-if="collectionStore.filterStatus !== 'none'"
+              size="x-small"
+              closable
+              class="ml-2"
+              @click:close="collectionStore.setStatusFilter('none')"
+            >
+              {{ statusFilterLabel }}
+            </v-chip>
+            <v-chip
+              v-if="collectionStore.filterYear !== 'all'"
+              size="x-small"
+              closable
+              class="ml-2"
+              @click:close="collectionStore.setYearFilter('all')"
+            >
+              {{ collectionStore.filterYear }}
+            </v-chip>
             <v-btn
               v-if="hasActiveFilters"
               size="x-small"
@@ -174,11 +192,10 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
-import { useCollectionStore, type FormatFilter, type SortOrder } from '@/stores/collection'
+import { useCollectionStore, type FormatFilter, type SortOrder, type StatusFilter } from '@/stores/collection'
 import { thumbnail } from '@/services/igdb'
 import { shortPlatform } from '@/services/platforms'
 import { prettyDate } from '@/services/utils'
-import type { Timestamp } from 'firebase/firestore'
 
 const collectionStore = useCollectionStore()
 
@@ -202,9 +219,20 @@ const sortLabel = computed(
   () => sortOptions.find(s => s.value === collectionStore.sortOrder)?.label ?? ''
 )
 
+const statusFilterLabels: Record<StatusFilter, string> = {
+  'none': '',
+  'completed': 'Completed',
+  'favorite': 'Favourites',
+  'this-month': 'Added This Month',
+  'hundred-percent': '100% Complete'
+}
+
+const statusFilterLabel = computed(() => statusFilterLabels[collectionStore.filterStatus])
+
 const hasActiveFilters = computed(() =>
   !!(collectionStore.filterText || collectionStore.filterPlatform ||
-     collectionStore.filterGenre || collectionStore.filterFormat !== 'all')
+     collectionStore.filterGenre || collectionStore.filterFormat !== 'all' ||
+     collectionStore.filterStatus !== 'none' || collectionStore.filterYear !== 'all')
 )
 
 function onSearch(val: string | null) {

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -18,7 +18,13 @@
       <!-- Stats row -->
       <v-row class="mb-6">
         <v-col cols="6" sm="3" v-for="stat in stats" :key="stat.label">
-          <v-card rounded="lg" variant="tonal" :color="stat.color">
+          <v-card
+            rounded="lg"
+            variant="tonal"
+            :color="stat.color"
+            class="stat-card"
+            @click="navigateWithFilter(stat.filter)"
+          >
             <v-card-text class="text-center pa-4">
               <div class="text-h4 font-weight-bold">{{ stat.value }}</div>
               <div class="text-caption text-medium-emphasis mt-1">{{ stat.label }}</div>
@@ -110,24 +116,34 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
-import { useCollectionStore } from '@/stores/collection'
+import { useCollectionStore, type StatusFilter } from '@/stores/collection'
 import { coverBig } from '@/services/igdb'
 import { Timestamp } from 'firebase/firestore'
 
 const authStore = useAuthStore()
 const collectionStore = useCollectionStore()
+const router = useRouter()
 const currentYear = new Date().getFullYear()
 
 function coverImage(cover: string | undefined) {
   return coverBig(cover)
 }
 
+function navigateWithFilter(status: StatusFilter) {
+  collectionStore.clearFilters()
+  if (status !== 'none') {
+    collectionStore.setStatusFilter(status)
+  }
+  router.push('/collection')
+}
+
 const stats = computed(() => [
-  { label: 'Total Games', value: collectionStore.games.length, color: 'primary' },
-  { label: 'Completed', value: collectionStore.games.filter(g => g.completed).length, color: 'success' },
-  { label: 'This Month', value: addedThisMonth.value, color: 'info' },
-  { label: 'Favourites', value: collectionStore.games.filter(g => g.favorite).length, color: 'warning' }
+  { label: 'Total Games', value: collectionStore.games.length, color: 'primary', filter: 'none' as StatusFilter },
+  { label: 'Completed', value: collectionStore.games.filter(g => g.completed).length, color: 'success', filter: 'completed' as StatusFilter },
+  { label: 'This Month', value: addedThisMonth.value, color: 'info', filter: 'this-month' as StatusFilter },
+  { label: 'Favourites', value: collectionStore.games.filter(g => g.favorite).length, color: 'warning', filter: 'favorite' as StatusFilter }
 ])
 
 const addedThisMonth = computed(() => {
@@ -186,5 +202,13 @@ const topPlatforms = computed(() => {
 }
 .game-cover:hover {
   transform: scale(1.04);
+}
+.stat-card {
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.stat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
 }
 </style>

--- a/src/views/StatisticsView.vue
+++ b/src/views/StatisticsView.vue
@@ -29,7 +29,13 @@
       <!-- Top stat chips -->
       <v-row class="mb-6">
         <v-col cols="6" sm="3" v-for="stat in summaryStats" :key="stat.label">
-          <v-card rounded="lg" variant="tonal" :color="stat.color">
+          <v-card
+            rounded="lg"
+            variant="tonal"
+            :color="stat.color"
+            class="stat-card"
+            @click="navigateWithFilter(stat.filter)"
+          >
             <v-card-text class="text-center pa-4">
               <div class="text-h4 font-weight-bold">{{ stat.value }}</div>
               <div class="text-caption text-medium-emphasis mt-1">{{ stat.label }}</div>
@@ -96,8 +102,9 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { Timestamp } from 'firebase/firestore'
-import { useCollectionStore } from '@/stores/collection'
+import { useCollectionStore, type StatusFilter } from '@/stores/collection'
 import StatStatusChart from '@/components/stats/StatStatusChart.vue'
 import StatPlatformChart from '@/components/stats/StatPlatformChart.vue'
 import StatGenreChart from '@/components/stats/StatGenreChart.vue'
@@ -105,6 +112,18 @@ import StatTimelineChart from '@/components/stats/StatTimelineChart.vue'
 import StatRatingChart from '@/components/stats/StatRatingChart.vue'
 
 const collectionStore = useCollectionStore()
+const router = useRouter()
+
+function navigateWithFilter(status: StatusFilter) {
+  collectionStore.clearFilters()
+  if (status !== 'none') {
+    collectionStore.setStatusFilter(status)
+  }
+  if (selectedYear.value !== 'all') {
+    collectionStore.setYearFilter(Number(selectedYear.value))
+  }
+  router.push('/collection')
+}
 const selectedYear = ref<string | number>('all')
 
 const availableYears = computed(() => {
@@ -135,22 +154,37 @@ const summaryStats = computed(() => [
   {
     label: 'Total Games',
     value: filteredGames.value.length,
-    color: 'primary'
+    color: 'primary',
+    filter: 'none' as StatusFilter
   },
   {
     label: 'Completed',
     value: filteredGames.value.filter(g => g.completed).length,
-    color: 'success'
+    color: 'success',
+    filter: 'completed' as StatusFilter
   },
   {
     label: 'Favourites',
     value: filteredGames.value.filter(g => g.favorite).length,
-    color: 'warning'
+    color: 'warning',
+    filter: 'favorite' as StatusFilter
   },
   {
     label: '100% Complete',
     value: filteredGames.value.filter(g => g.hundredpercent).length,
-    color: 'secondary'
+    color: 'secondary',
+    filter: 'hundred-percent' as StatusFilter
   }
 ])
 </script>
+
+<style scoped>
+.stat-card {
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.stat-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15) !important;
+}
+</style>


### PR DESCRIPTION
…ollection

Clicking a stat card navigates to the collection with the matching filter applied (completed, favourites, added this month, 100% complete). Stats in the statistics view also carry the selected year into the collection filter. Active status and year filters appear as dismissible chips in the collection toolbar.